### PR TITLE
switched to new omfit_classes package and modified user agreement

### DIFF
--- a/USER_AGREEMENT.txt
+++ b/USER_AGREEMENT.txt
@@ -1,22 +1,22 @@
-Aurora User Agreement (2020.10.31) 
+Aurora User Agreement (2021.02.13) 
 
 By cloning, downloading or otherwise using Aurora sources, the recipient
 agrees:
 
 1. To compile/use the Software source code AS IS for publication
    purposes; users however are welcome to request changes, to make
-   code modifications for testing purposes, or issue pull requests.
+   code modifications for testing purposes, or open pull requests.
 
 2. If the authorized user’s copy of Software is made available to third
    parties, to ensure that the user agreement is followed by the third
    parties.
 
-3. To email a draft of any article/letter/note based on the Software
-   use to sciortino@psfc.mit.edu.
-
-4. To include in published results or presentations the code name
-   and appropriate references for both Aurora [1] and STRAHL [2], on which 
-   part of the Aurora code was originally based. 
+3. To appropriately reference in any publications, talks and posters the key works
+   that led to the current version of Aurora [1] as well as STRAHL [2], on which 
+   part of the package was originally based. Aurora is also integrated
+   with Python tools developed by the OMFIT community; Python users should
+   therefore also cite [3].
 
 [1] F. Sciortino et al 2020 Nucl. Fusion 60 126014, https://doi.org/10.1088/1741-4326/abae85
 [2] R. Dux, IPP Report, 2004, https://pure.mpg.de/rest/items/item_2136655/component/file_2136654/content 
+[3] O. Meneghini and L. Lao, 2013, Plasma Fusion Res. 8, 2403009, http://www.jspf.or.jp/PFR/PFR_articles/pfr2013S1/pfr2013_08-2403009.html

--- a/aurora/coords.py
+++ b/aurora/coords.py
@@ -59,7 +59,7 @@ def vol_average(quant, rhop, method='omfit', geqdsk=None, device=None, shot=None
         try:
             from omfit_classes import omfit_eqdsk
         except:
-            raise ValueError('Could not import omfit_eqdsk! Install with pip install omfit_eqdsk')
+            raise ValueError('Could not import omfit_classes.omfit_eqdsk! Install with pip install omfit_classes')
         geqdsk = omfit_eqdsk.OMFITgeqdsk('').from_mdsplus(
             device=device, shot=shot, time=time, SNAPfile='EFIT01',
             fail_if_out_of_range=False,time_diff_warning_threshold=20)

--- a/aurora/coords.py
+++ b/aurora/coords.py
@@ -27,18 +27,18 @@ def vol_average(quant, rhop, method='omfit', geqdsk=None, device=None, shot=None
         coordinates. The methods only slightly differ in their results. Note that 'omfit' will fail if 
         rhop extends beyond the LCFS, while method 'fs' can estimate volume averages also into the SOL.
         Default is method='omfit'. 
-    geqdsk : output of the omfit_eqdsk.OMFITgeqdsk class, postprocessing the EFIT geqdsk file
+    geqdsk : output of the :py:class:`omfit_classes.omfit_eqdsk.OMFITgeqdsk` class, postprocessing the EFIT geqdsk file
         containing the magnetic geometry. If this is left to None, the function internally tries to fetch
-        it using MDS+ and omfit_eqdsk. In this case, device, shot and time to fetch the equilibrium 
+        it using MDS+ and `omfit_classes.omfit_eqdsk`. In this case, device, shot and time to fetch the equilibrium 
         are required. 
     device : str
-        Device name. Note that routines for this device must be implemented in omfit_eqdsk for this to work. 
+        Device name. Note that routines for this device must be implemented in `omfit_classes.omfit_eqdsk` for this to work. 
     shot : int
         Shot number of the above device, e.g. 1101014019 for C-Mod.
     time : float
         Time at which equilibrium should be fetched in units of ms. 
     return_geqdsk : bool
-        If True, omfit_eqdsk dictionary is also returned
+        If True, `omfit_classes.omfit_eqdsk` dictionary is also returned
 
     Returns
     -------
@@ -57,12 +57,12 @@ def vol_average(quant, rhop, method='omfit', geqdsk=None, device=None, shot=None
     if geqdsk is None:
         # Fetch device geqdsk from MDS+ and post-process it using the OMFIT geqdsk format.
         try:
-                import omfit_eqdsk
+            from omfit_classes import omfit_eqdsk
         except:
-                raise ValueError('Could not import omfit_eqdsk! Install with pip install omfit_eqdsk')
-        geqdsk = omfit_eqdsk.OMFITgeqdsk('').from_mdsplus(device=device, shot=shot,
-                                                          time=time, SNAPfile='EFIT01',
-                                                          fail_if_out_of_range=False,time_diff_warning_threshold=20)
+            raise ValueError('Could not import omfit_eqdsk! Install with pip install omfit_eqdsk')
+        geqdsk = omfit_eqdsk.OMFITgeqdsk('').from_mdsplus(
+            device=device, shot=shot, time=time, SNAPfile='EFIT01',
+            fail_if_out_of_range=False,time_diff_warning_threshold=20)
 
     if method=='fs':
         # obtain mapping between rhop and r_V coordinates

--- a/aurora/core.py
+++ b/aurora/core.py
@@ -61,7 +61,7 @@ class aurora_sim:
         self.imp = namelist['imp']
 
         # import omfit_eqdsk here to avoid issues with docs and packaging
-        import omfit_eqdsk
+        from omfit_classes import omfit_eqdsk
         if geqdsk is None:
             # Fetch geqdsk from MDS+ (using EFIT01) and post-process it using the OMFIT geqdsk format.
             self.geqdsk = omfit_eqdsk.OMFITgeqdsk('').from_mdsplus(
@@ -93,7 +93,7 @@ class aurora_sim:
             self.saw_on[self.time_grid.searchsorted(self.saw_times)] = 1
 
         # import here to avoid issues when building docs or package
-        from omfit_commonclasses.utils_math import atomic_element
+        from omfit_classes.utils_math import atomic_element
 
         # get nuclear charge Z and atomic mass number A
         out = atomic_element(symbol=self.imp)
@@ -320,7 +320,7 @@ class aurora_sim:
         
         '''
         # import here to avoid issues when building docs or package
-        from omfit_commonclasses.utils_math import atomic_element
+        from omfit_classes.utils_math import atomic_element
 
         # background mass number (=2 for D)
         out = atomic_element(symbol=self.namelist['main_element'])

--- a/aurora/core.py
+++ b/aurora/core.py
@@ -26,7 +26,7 @@ class aurora_sim:
         Dictionary containing aurora inputs. See default_nml.py for some defaults, 
         which users should modify for their runs.
     geqdsk : dict, optional
-        EFIT gfile as returned after postprocessing by the :py:mod:`omfit_eqdsk` 
+        EFIT gfile as returned after postprocessing by the :py:mod:`omfit_classes.omfit_eqdsk` 
         package (OMFITgeqdsk class). If left to None (default), the geqdsk dictionary 
         is constructed starting from the gfile in the MDS+ tree indicated in the namelist.
     nbi_cxr : array, optional

--- a/aurora/core.py
+++ b/aurora/core.py
@@ -18,39 +18,36 @@ from . import synth_diags
 
 
 class aurora_sim:
-    '''
-    Class to setup and run aurora simulations.
+    '''Setup the input dictionary for an Aurora ion transport simulation from the given namelist.
+
+    Parameters
+    ----------
+    namelist : dict
+        Dictionary containing aurora inputs. See default_nml.py for some defaults, 
+        which users should modify for their runs.
+    geqdsk : dict, optional
+        EFIT gfile as returned after postprocessing by the :py:mod:`omfit_eqdsk` 
+        package (OMFITgeqdsk class). If left to None (default), the geqdsk dictionary 
+        is constructed starting from the gfile in the MDS+ tree indicated in the namelist.
+    nbi_cxr : array, optional
+        If namelist['nbi_cxr']=True, this array represents the charge exchange rates 
+        with NBI neutrals, fast and/or thermal, across the entire radius and on the 
+        time base of interest. 
+        Creating this input is not trivial and must be done externally to aurora. 
+        General steps:
+        - get density of fast NBI neutrals (both fast and thermal/halo) ---> n0_nbi, n0_halo
+        - get total rates (n-unresolved) for CX with NBI neutrals --> _alpha_CX_NBI_rates
+        - thermal rates for the halo may be from ADAS CCD files or from the same methods used 
+        for fast neutrals
+        - sum n0_nbi *  alpha_CX_NBI_rates + n0_halo * alpha_CX_rates
+        This method still needs more testing within this class. Contact sciortino@psfc.mit.edu for details. 
+    setup2load : str, optional
+        Path to file from which Aurora simulation setup should be loaded. 
+        This is expected in pickle format, e.g. "test.pkl". Any `aurora_sim` instance
+        can be saved to file using the :py:meth:`~aurora.core.save` method.             
+
     '''
     def __init__(self, namelist={}, geqdsk=None, nbi_cxr=None, pickle2load=None):
-        '''Setup aurora simulation input dictionary from the given namelist.
-
-        Parameters
-        -----------------
-        namelist : dict
-            Dictionary containing aurora inputs. See default_nml.py for some defaults, 
-            which users should modify for their runs.
-        geqdsk : dict, optional
-            EFIT gfile as returned after postprocessing by the :py:mod:`omfit_eqdsk` 
-            package (OMFITgeqdsk class). If left to None (default), the geqdsk dictionary 
-            is constructed starting from the gfile in the MDS+ tree indicated in the namelist.
-        nbi_cxr : array, optional
-            If namelist['nbi_cxr']=True, this array represents the charge exchange rates 
-            with NBI neutrals, fast and/or thermal, across the entire radius and on the 
-            time base of interest. 
-            Creating this input is not trivial and must be done externally to aurora. 
-            General steps:
-            - get density of fast NBI neutrals (both fast and thermal/halo) ---> n0_nbi, n0_halo
-            - get total rates (n-unresolved) for CX with NBI neutrals --> _alpha_CX_NBI_rates
-            - thermal rates for the halo may be from ADAS CCD files or from the same methods used 
-            for fast neutrals
-            - sum n0_nbi *  alpha_CX_NBI_rates + n0_halo * alpha_CX_rates
-            This method still needs more testing within this class. Contact sciortino@psfc.mit.edu for details. 
-        setup2load : str, optional
-            Path to file from which Aurora simulation setup should be loaded. 
-            This is expected in pickle format, e.g. "test.pkl". Any `aurora_sim` instance
-            can be saved to file using the :py:meth:`~aurora.core.save` method.             
-
-        '''
         if pickle2load is not None:
             self.load(pickle2load)
             return

--- a/aurora/grids_utils.py
+++ b/aurora/grids_utils.py
@@ -372,8 +372,7 @@ def get_HFS_LFS(geqdsk, rho_pol=None):
     Parameters
     ----------
     geqdsk : dict
-        Dictionary containing the g-EQDSK file as processed by the *omfit_eqdsk*
-        package. 
+        Dictionary containing the g-EQDSK file as processed by the `omfit_classes.omfit_eqdsk`. 
     rho_pol : array, optional
         Array corresponding to a grid in sqrt of normalized poloidal flux for which a 
         corresponding rvol grid should be found. If left to None, an arbitrary grid will be 
@@ -436,8 +435,7 @@ def get_rhopol_rvol_mapping(geqdsk, rho_pol=None):
     Parameters
     ----------
     geqdsk : dict
-        Dictionary containing the g-EQDSK file as processed by the *omfit_eqdsk*
-        package. 
+        Dictionary containing the g-EQDSK file as processed by `omfit_classes.omfit_eqdsk`. 
     rho_pol : array, optional
         Array corresponding to a grid in sqrt of normalized poloidal flux for which a 
         corresponding rvol grid should be found. If left to None, an arbitrary grid will be 
@@ -606,7 +604,7 @@ def estimate_clen(geqdsk):
     Parameters
     ----------
     geqdsk : dict
-        EFIT g-EQDSK as processed by the omfit_eqdsk package.
+        EFIT g-EQDSK as processed by `omfit_classes.omfit_eqdsk`.
 
     Returns
     -------
@@ -659,7 +657,7 @@ def estimate_boundary_distance(shot, device, time_ms):
         taken to be 2/3 of the bound_sep distance.    
     '''
     # import this here, so that it is not required for the whole package
-    from omfit_mds import OMFITmdsValue
+    from omfit_classes.omfit_mds import OMFITmdsValue
 
     try:
         tmp = OMFITmdsValue(server=device, treename='EFIT01', shot=shot,

--- a/aurora/kn1d.py
+++ b/aurora/kn1d.py
@@ -48,8 +48,8 @@ def _setup_kin_profs(rhop, ne_cm3, Te_eV, Ti_eV,
         Electron temperature on rhop grid [:math:`eV`].
     Ti_eV : 1D array
         Main ion temperature on rhop grid [:math:`eV`].
-    geqdsk : `omfit_eqdsk.OMFITgeqdsk` class instance
-        gEQDSK file as processed by the `omfit_eqdsk.OMFITgeqdsk` class.
+    geqdsk : `omfit_classes.omfit_eqdsk.OMFITgeqdsk` class instance
+        gEQDSK file as processed by the `omfit_classes.omfit_eqdsk.OMFITgeqdsk` class.
     bound_sep_cm : float
         Distance between the wall/boundary and the separatrix [:math:`cm`].
     lim_sep_cm : float
@@ -192,8 +192,8 @@ def run_kn1d(rhop, ne_cm3, Te_eV, Ti_eV, geqdsk, p_H2_mTorr,
         Electron temperature on rhop grid [:math:`eV`].
     Ti_eV : 1D array
         Main ion temperature on rhop grid [:math:`eV`].
-    geqdsk : `omfit_eqdsk.OMFITgeqdsk` class instance
-        gEQDSK file as processed by the `omfit_eqdsk.OMFITgeqdsk` class.
+    geqdsk : `omfit_classes.omfit_eqdsk.OMFITgeqdsk` class instance
+        gEQDSK file as processed by the `omfit_classes.omfit_eqdsk.OMFITgeqdsk` class.
     p_H2_mTorr : float
         Pressure of molecular hydrogen-isotopes measured at the wall. This may be estimated
         from experimental pressure gauges. This variable effectively sets the amplitude of the 

--- a/aurora/nbi_neutrals.py
+++ b/aurora/nbi_neutrals.py
@@ -36,8 +36,8 @@ def get_neutrals_fsa(neutrals, geqdsk, debug_plots=True):
 
         It is currently assumed that n=0,1 and 2 beam components are provided by the user. 
 
-    geqdsk : dictionary output of `omfit_eqdsk.OMFITgeqdsk` class
-        gEQDSK post-processed dictionary, as given by the omfit_eqdsk package. 
+    geqdsk : dictionary output of `omfit_classes.omfit_eqdsk.OMFITgeqdsk` class
+        gEQDSK post-processed dictionary, as given by `omfit_classes.omfit_eqdsk`. 
     debug_plots : bool, optional
         If True, various plots are displayed. 
 

--- a/aurora/neutrals.py
+++ b/aurora/neutrals.py
@@ -387,8 +387,8 @@ def Lya_to_neut_dens(emiss_prof, ne, Te, ni=None, plot=True, rhop=None,
         log10pec_dict = radiation.read_adf15(path)[1215.2]
 
         # evaluate these interpolations on our profiles
-        pec_recomb = log10pec_dict['recom'].ev(np.log10(ne), np.log10(Te))
-        pec_exc = log10pec_dict['excit'].ev(np.log10(ne), np.log10(Te))
+        pec_recomb = 10**log10pec_dict['recom'].ev(np.log10(ne), np.log10(Te))
+        pec_exc = 10**log10pec_dict['excit'].ev(np.log10(ne), np.log10(Te))
 
         N1 = emiss_prof/E_21/(ne*pec_exc+ni*pec_recomb)
 

--- a/aurora/radiation.py
+++ b/aurora/radiation.py
@@ -792,7 +792,7 @@ def get_local_spectrum(adf15_filepath, ion, ne_cm3, Te_eV, n0_cm3=0.0,
     cs = adf15_filepath.split('#')[-1].split('.dat')[0]
     
     # import here to avoid issues when building docs or package
-    from omfit_commonclasses.utils_math import atomic_element
+    from omfit_classes.utils_math import atomic_element
     
     # get nuclear charge Z and atomic mass number A
     out = atomic_element(symbol=ion)

--- a/aurora/radiation.py
+++ b/aurora/radiation.py
@@ -738,6 +738,8 @@ def get_local_spectrum(adf15_filepath, ion, ne_cm3, Te_eV,
         If True, no plot legend is shown. Default is False, i.e. show legend.
     plot_all_lines : bool
         If True, plot all individual lines, rather than just the profiles due to different atomic processes.
+        If more than 50 lines are included, a down-selection is automatically made to avoid excessive
+        memory consumption.
 
     Returns
     -------
@@ -862,40 +864,49 @@ def get_local_spectrum(adf15_filepath, ion, ne_cm3, Te_eV,
     if plot and ax is None:
         fig,ax = plt.subplots()
 
+    many_lines=False
+    if len(wave_A)>50:
+        many_lines=True
+
     # contributions to spectrum
     spec_ion = np.zeros_like(wave_final_A)
     for ii in np.arange(lams_profs_A.shape[0]):
         comp_ion = interp1d(lams_profs_A[ii,:], ne_cm3*ion_exc_rec_dens[0]*pec_ion[ii]*theta[ii,:],
                                bounds_error=False, fill_value=0.0)(wave_final_A)
-        if plot_all_lines: ax.plot(wave_final_A, comp_ion, c='r')
+        if plot_all_lines and many_lines and pec_ion[ii]>np.max(pec_ion)/100:
+            ax.plot(wave_final_A+dlam_A, comp_ion, c='r')
         spec_ion += comp_ion
 
     spec_exc = np.zeros_like(wave_final_A)
     for ii in np.arange(lams_profs_A.shape[0]):
         comp_exc = interp1d(lams_profs_A[ii,:], ne_cm3*ion_exc_rec_dens[1]*pec_exc[ii]*theta[ii,:],
                                bounds_error=False, fill_value=0.0)(wave_final_A)
-        if plot_all_lines: ax.plot(wave_final_A, comp_exc, c='b')
+        if plot_all_lines and many_lines and pec_exc[ii]>np.max(pec_exc)/100:
+            ax.plot(wave_final_A+dlam_A, comp_exc, c='b')
         spec_exc += comp_exc
 
     spec_rr = np.zeros_like(wave_final_A)
     for ii in np.arange(lams_profs_A.shape[0]):
         comp_rr = interp1d(lams_profs_A[ii,:], ne_cm3*ion_exc_rec_dens[2]*pec_rr[ii]*theta[ii,:],
                                bounds_error=False, fill_value=0.0)(wave_final_A)
-        if plot_all_lines: ax.plot(wave_final_A, comp_rr, c='g')
+        if plot_all_lines and many_lines and pec_rr[ii]>np.max(pec_rr)/100:
+            ax.plot(wave_final_A+dlam_A, comp_rr, c='g')
         spec_rr += comp_rr
 
     spec_dr = np.zeros_like(wave_final_A)
     for ii in np.arange(lams_profs_A.shape[0]):
         comp_dr = interp1d(lams_profs_A[ii,:], ne_cm3*ion_exc_rec_dens[2]*pec_dr[ii]*theta[ii,:],
                                bounds_error=False, fill_value=0.0)(wave_final_A)
-        if plot_all_lines: ax.plot(wave_final_A, comp_dr, c='g')
+        if plot_all_lines and many_lines and pec_dr[ii]>np.max(pec_dr)/100:
+            ax.plot(wave_final_A+dlam_A, comp_dr, c='g')
         spec_dr += comp_dr
 
     spec_cx = np.zeros_like(wave_final_A)
     for ii in np.arange(lams_profs_A.shape[0]):
         comp_cx = interp1d(lams_profs_A[ii,:], n0_cm3*ion_exc_rec_dens[2]*pec_cx[ii]*theta[ii,:],
                                bounds_error=False, fill_value=0.0)(wave_final_A)
-        if plot_all_lines: ax.plot(wave_final_A, comp_cx, c='g')
+        if plot_all_lines and many_lines and pec_cx[ii]>np.max(pec_cx)/100:
+            ax.plot(wave_final_A+dlam_A, comp_cx, c='g')
         spec_cx += comp_cx
 
     spec_tot = spec_ion+spec_exc+spec_rr+spec_dr+spec_cx

--- a/aurora/solps.py
+++ b/aurora/solps.py
@@ -30,9 +30,9 @@ class solps_case:
             can be found. 
             If form='full', this path indicates where to find the directory named "baserun"
             and the 'solps_run' one.
-        geqdsk : str or `omfit_geqdsk` class instance
-            Path to the geqdsk to load from disk, or instance of the `omfit_geqdsk` class that
-            contains the processed gEQDSK file already. 
+        geqdsk : str or `omfit_classes.omfit_geqdsk.OMFITgeqdsk` class instance
+            Path to the geqdsk to load from disk, or instance of the `omfit_classes.omfit_geqdsk.omfit_geqdsk` 
+            class that contains the processed gEQDSK file already. 
         solps_run : str
             If form='full', this string specifies the directory (relative to the given path)
             where case-specific files for a SOLPS run can be found (e.g. 'b2fstate').
@@ -57,7 +57,7 @@ class solps_case:
         self.form = form
         
         if isinstance(geqdsk, str): # user passed a path to a gfile on disk
-            import omfit_eqdsk # import omfit_eqdsk here to avoid issues with docs and packaging
+            from omfit_classes import omfit_eqdsk # import omfit_eqdsk here to avoid issues with docs and packaging
             self.geqdsk = omfit_eqdsk.OMFITgeqdsk(geqdsk)
         else:
             self.geqdsk = geqdsk
@@ -86,7 +86,7 @@ class solps_case:
             self.double_null = False # TODO: generalize for double null shapes!
 
         elif form=='full':
-            import omfit_solps # import omfit_solps here to avoid issues with docs and packaging
+            from omfit_classes import omfit_solps # import omfit_solps here to avoid issues with docs and packaging
             self.b2fstate = omfit_solps.OMFITsolps(path+os.sep+solps_run+os.sep+'b2fstate')
             self.geom = omfit_solps.OMFITsolps(path+os.sep+'baserun'+os.sep+'b2fgmtry')
 
@@ -545,8 +545,7 @@ def apply_mask(triang, geqdsk, max_mask_len=0.4, mask_up=False, mask_down=False)
     triang : instance of matplotlib.tri.triangulation.Triangulation
         Matplotlib triangulation object for the (R,Z) grid. 
     geqdsk : dict
-        Dictionary containing gEQDSK file values as processed by the `omfit_eqdsk`
-        package. 
+        Dictionary containing gEQDSK file values as processed by `omfit_classes.omfit_eqdsk`. 
     max_mask_len : float
         Maximum length [m] of segments within the triangulation. Segments longer
         than this value will not be plotted. This helps avoiding triangulation 

--- a/aurora/source_utils.py
+++ b/aurora/source_utils.py
@@ -284,7 +284,7 @@ def get_radial_source(namelist, rvol_grid, pro_grid, S_rates, Ti_eV=None):
                 raise ValueError('Could not compute a valid energy of injected ions!')
 
         # import here to avoid issues with omfit_commonclasses during docs and package creation
-        from omfit_commonclasses.utils_math import atomic_element
+        from omfit_classes.utils_math import atomic_element
 
         # velocity of neutrals [cm/s]
         out = atomic_element(symbol=namelist['main_element'])

--- a/aurora/synth_diags.py
+++ b/aurora/synth_diags.py
@@ -96,7 +96,7 @@ def centrifugal_asym(rhop, Rlfs, omega, Zeff, A_imp, Z_imp, Te, Ti,
     nz : array (nr,nZ)
         Impurity charge state densities (output of Aurora at a specific time slice), only used for 2D plotting.
     geqdsk : dict
-        Dictionary containing the `omfit_eqdsk` reading of the EFIT g-file. 
+        Dictionary containing the `omfit_classes.omfit_eqdsk` reading of the EFIT g-file. 
 
     Returns
     -------

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -18,13 +18,17 @@ Note that you can always look at where this function is defined in the package b
 
   aurora.load_default_namelist.__module__
 
-Once you have loaded the default namelist, have a look at the `namelist` dictionary. It contains a number of parameters that are needed for Aurora runs. Some of them, like the name of the device, are only important if automatic fetching of the EFIT equilibrium through `MDSplus` is required, or else it can be ignored (leaving it to its default value). Most of the parameter names should be fairly self-descriptive, but a detailed description will be available soon. In the meantime, please refer to docstrings through the code documentation.
+Once you have loaded the default namelist, have a look at the `namelist` dictionary. It contains a number of parameters that are needed for Aurora runs. Some of them, like the name of the device, are only important if automatic fetching of the EFIT equilibrium through `MDSplus` is required, or else it can be ignored (leaving it to its default value). Most of the parameter names should be fairly self-descriptive. Please refer to docstrings throughout the code documentation.
 
-Next, read in a magnetic equilibrium. You can find an example from a C-Mod discharge in the `examples` directory::
+Aurora leverages the `omfit_classes` package to interface with MDS+, EFIT, and a number of other codes. Thanks to this, users can focus more on their applications of interest, and less on re-inventing the wheel to write code that the OMFIT Team has kindly made public! To follow the rest of this tutorial, do::
+
+  from omfit_classes import omfit_eqdsk, omfit_gapy
+
+Next, we read in a magnetic equilibrium. You can find an example from a C-Mod discharge in the `examples` directory::
   
   geqdsk = omfit_eqdsk.OMFITgeqdsk('example.gfile')
 
-The output `geqdsk` dictionary contains the contents of the EFIT geqdsk file, with additional processing done by the `omfit_eqdsk` package for flux surfaces. Only some of the dictionary fields are used; refer to the :py:mod:`~aurora.grids_utils` methods for details. The `geqdsk` dictionary is used to create a mapping between the `rhop` grid (square root of normalized poloidal flux) and a `rvol` grid, defined by the normalized volume of each flux surface. Aurora, like STRAHL, runs its simulations on the `rvol` grid. 
+The output `geqdsk` dictionary contains the contents of the EFIT geqdsk file, with additional processing done by the `omfit_classes` package for flux surfaces. Only some of the dictionary fields are used; refer to the :py:mod:`~aurora.grids_utils` methods for details. The `geqdsk` dictionary is used to create a mapping between the `rhop` grid (square root of normalized poloidal flux) and a `rvol` grid, defined by the normalized volume of each flux surface. Aurora, like STRAHL, runs its simulations on the `rvol` grid. 
 
 We next need to read in some kinetic profiles, for example from an `input.gacode` file (available in the `examples` directory)::
   

--- a/examples/aurora_kn1d.py
+++ b/examples/aurora_kn1d.py
@@ -9,7 +9,7 @@ sciortino, Jan 2021
 import numpy as np
 import matplotlib.pyplot as plt
 plt.ion()
-import omfit_eqdsk, omfit_gapy
+from omfit_classes import omfit_eqdsk, omfit_gapy
 import sys, os
 from scipy.interpolate import interp1d
 

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -7,7 +7,7 @@ It is recommended to run this in IPython.
 import numpy as np
 import matplotlib.pyplot as plt
 plt.ion()
-import omfit_eqdsk, omfit_gapy
+from omfit_classes import omfit_eqdsk, omfit_gapy
 import sys, os
 from scipy.interpolate import interp1d
 

--- a/examples/compare_algorithms.py
+++ b/examples/compare_algorithms.py
@@ -6,7 +6,7 @@ It is recommended to run this in IPython.
 
 import numpy as np
 import matplotlib.pyplot as plt; plt.ion()
-import omfit_eqdsk, omfit_gapy
+from omfit_classes import omfit_eqdsk, omfit_gapy
 import pickle as pkl
 import scipy,sys,os
 import time

--- a/examples/create_animation.py
+++ b/examples/create_animation.py
@@ -7,7 +7,7 @@ Note that you might need to run %matplotlib qt in IPython in order to enable the
 
 import numpy as np
 import matplotlib.pyplot as plt; plt.ion()
-import omfit_eqdsk, omfit_gapy
+from omfit_classes import omfit_eqdsk, omfit_gapy
 import pickle as pkl
 import scipy,sys,os
 import time

--- a/examples/iterative_example.py
+++ b/examples/iterative_example.py
@@ -10,7 +10,7 @@ jmcclena and sciortino, Nov 2020
 import numpy as np
 import matplotlib.pyplot as plt
 plt.ion()
-import omfit_eqdsk, omfit_gapy
+from omfit_classes import omfit_eqdsk, omfit_gapy
 import sys, copy, os
 from scipy.interpolate import interp1d
 

--- a/examples/julia_benchmark.py
+++ b/examples/julia_benchmark.py
@@ -4,7 +4,7 @@ Script to benchmark basic Julia version against Fortran one.
 
 import numpy as np
 import matplotlib.pyplot as plt
-import omfit_eqdsk, omfit_gapy
+from omfit_classes import omfit_eqdsk, omfit_gapy
 import pickle as pkl
 import scipy,sys,os
 import time

--- a/examples/test_FSA.py
+++ b/examples/test_FSA.py
@@ -8,7 +8,7 @@ It is recommended to run this in IPython.
 import numpy as np
 import matplotlib.pyplot as plt
 plt.ion()
-import omfit_eqdsk, omfit_gapy
+from omfit_classes import omfit_eqdsk, omfit_gapy
 import scipy,sys,os
 import time
 from scipy.interpolate import interp1d

--- a/meta.yaml
+++ b/meta.yaml
@@ -38,7 +38,7 @@ about:
   license_file: USER_AGREEMENT.txt
   summary: 'Modern toolbox for impurity transport, neutrals and radiation modeling in fusion plasmas'
   description: |
-    Aurora is a package to simulate heavy-ion transport and radiation in magnetically-confined plasmas. 
+    Aurora is a package to simulate heavy-ion transport, neutrals and radiation in magnetically-confined plasmas. 
     It offers a 1.5D impurity transport forward model inheriting from the historical STRAHL code, 
     with which it has been thoroughly benchmarked. Routines to analyze neutral states of hydrogen 
     isotopes, both from the edge of fusion plasmas and from neutral beam injection, allow integration 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ scipy
 matplotlib
 xarray
 pexpect
+omfit_classes


### PR DESCRIPTION
Switch Aurora to use new `omfit_classes` package and specify that users cite OMFIT when using Python tools in Aurora. 

Outstanding issue before this is merged into master: `omfit_classes` currently prints to screen all the PYTHONPATH during the import. This is pretty annoying and can probably be avoided. @orso82 could you please have a look?

Also, did I get the OMFIT reference right in the Aurora user agreement? I took it from [the OMFIT user agreement](https://docs.google.com/forms/d/e/1FAIpQLSdHRDmTh5Kc0iVFKfUFonmC25C7DyMUIhlVFX2hh5XWyR2q4A/viewform).