### PR TITLE
Provide parsed ADF15 files in the form of pandas DataFrames

### DIFF
--- a/aurora/radiation.py
+++ b/aurora/radiation.py
@@ -44,7 +44,6 @@ def compute_rad(
     Te,
     n0=None,
     Ti=None,
-    ni=None,
     adas_files_sub={},
     prad_flag=False,
     sxr_flag=False,

--- a/aurora/radiation.py
+++ b/aurora/radiation.py
@@ -629,13 +629,13 @@ def read_adf15(path, order=1):
     >>> # load all transitions provided in the chosen ADF15 file:
     >>> trs = aurora.read_adf15(path)
     >>> # select the excitation-driven component of the Lyman-alpha transition:
-    >>> tr = trs[(trs['lambda [A]']==1215.2) & (trs['type']=='EXCIT')]
+    >>> tr = trs[(trs['lambda [A]']==1215.2) & (trs['type']=='excit')]
     >>> # now plot the rates:
     >>> aurora.plot_pec(tr)
 
     Note that excitation-, recombination- and charge-exchange driven components can
     be fetched in the same way by specifying the `type`, e.g. using
-    >>> trs['type']=='EXCIT' # 'EXCIT', 'RECOM' or 'CHEXC'
+    >>> trs['type']=='excit' # 'excit', 'recom' or 'chexc'
 
     Since the output of `aurora.radiation.read_adf15` is a pandas DataFrame, its contents
     can be indexed in a variety of ways, e.g. one can select a line based on the 
@@ -931,6 +931,10 @@ def parse_adf15_spec(lines, num_lines):
 
     # make wavelengths into floats and change nomenclature
     d['lambda [A]'] = np.array(d[headers[1]], dtype=float)
+    if headers[1]!='lambda [A]': del d[headers[1]]
+    
+    # ensure consistency of labels across files
+    d['type'] = np.array([val.lower() for val in d['type']])
 
     # return as a pandas DataFrame
     return pd.DataFrame(data=d)

--- a/aurora/radiation.py
+++ b/aurora/radiation.py
@@ -772,7 +772,7 @@ def _find_adf15_spacing(l):
     splitvals = []
     for elem in l.split():
         for m in re.finditer(' '+elem,l):
-            pair = [m.start()+1, m.end()+1] # read additional end character
+            pair = [m.start(), m.end()+1] # read additional end character
             if pair not in splitvals:
                 splitvals.append(pair)
     # re-order pairs
@@ -924,6 +924,8 @@ def parse_adf15_spec(lines, num_lines):
         try:
             assert d['isel'][-1]==i
         except:
+            from IPython import embed
+            embed()
             raise ValueError(f'Some issue with file parsing for ISEL={i+1}')
             
     # make wavelengths into floats and change nomenclature

--- a/aurora/radiation.py
+++ b/aurora/radiation.py
@@ -934,7 +934,7 @@ def parse_adf15_spec(lines, num_lines):
     if headers[1]!='lambda [A]': del d[headers[1]]
     
     # ensure consistency of labels across files
-    d['type'] = np.array([val.lower() for val in d['type']])
+    d['type'] = np.array([val.lower().strip() for val in d['type']])
 
     # return as a pandas DataFrame
     return pd.DataFrame(data=d)
@@ -964,10 +964,10 @@ def plot_pec(transition, ax=None, plot_3d=False):
     Alternatively, to select a line using the ADAS "ISEL" indices:
     >>> aurora.plot_pec(out.loc[(out['isel']==1)])
     """
-    dens = np.array(transition['dens pnts'])[0]
-    temp = np.array(transition['temp pnts'])[0]
-    PEC_pnts = np.array(transition['PEC pnts'])[0]
-    pec_fun = np.array(transition['log10 PEC fun'])[0]
+    dens = np.atleast_1d(transition['dens pnts'])[0]
+    temp = np.atleast_1d(transition['temp pnts'])[0]
+    PEC_pnts = np.atleast_1d(transition['PEC pnts'])[0]
+    pec_fun = np.atleast_1d(transition['log10 PEC fun'])[0]
     
     # plot PEC values over ne,Te grid given by ADAS, showing interpolation validity
     NE, TE = np.meshgrid(dens, temp)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ matplotlib
 pexpect
 omfit_classes
 requests
+pandas


### PR DESCRIPTION
Significant changes to the `aurora.radiation.read_adf15` function. This is NOT a backwards-compatible change and will therefore require that all Aurora users are made aware of the change and of the nice new capabilities that are now available. 

I copy here below a section of the updated docs for the `read_adf15` function, useful for testing:

```
    To plot the Lyman-alpha photon emissivity coefficients for H (or its isotopes), one can use:

    >>> import aurora
    >>> filename = 'pec96#h_pju#h0.dat'
    >>> # fetch file automatically, locally, from AURORA_ADAS_DIR, or directly from the web:
    >>> path = aurora.get_adas_file_loc(filename, filetype='adf15')  
    >>> # load all transitions provided in the chosen ADF15 file:
    >>> trs = aurora.read_adf15(path)
    >>> # select the excitation-driven component of the Lyman-alpha transition:
    >>> tr = trs[(trs['lambda [A]']==1215.2) & (trs['type']=='excit')]
    >>> # now plot the rates:
    >>> aurora.plot_pec(tr)

    Note that excitation-, recombination- and charge-exchange driven components can
    be fetched in the same way by specifying the `type`, e.g. using
    >>> trs['type']=='excit' # 'excit', 'recom' or 'chexc'

    Since the output of `aurora.radiation.read_adf15` is a pandas DataFrame, its contents
    can be indexed in a variety of ways, e.g. one can select a line based on the 
    ADAS "ISEL" indices and plot it using
    >>> aurora.plot_pec(trs.loc[(trs['isel']==1)])
    or simply
    >>> aurora.plot_pec(trs.iloc[0])
    Spectral lines are ordered by ISEL numbers -1 (Python indexing!), so using the 
    `iloc` method of a pandas DataFrame allows effective indexing by ISEL numbers.

    The log-10 of the PEC interpolation function can be used as
    >>> tr['log10 PEC fun'].iloc[0].ev(np.log10(ne_cm3), np.log10(Te_eV))
    where the interpolant was evaluated (via the `ev` method) at specific points of `n_e`
    (units of [:math:`cm^{-3}`]) and `T_e` (units of :math:`eV`). Note that the log-10
    of `n_e` and `T_e` is needed, not `n_e` and `T_e` themselves!

    Metastable-resolved files are automatically identified based on the file nomenclature
    and parsed accordingly, e.g.::

    >>> filename = 'pec96#he_pjr#he0.dat'
    >>> path = aurora.get_adas_file_loc(filename, filetype='adf15')
    >>> trs = aurora.read_adf15(path)
    >>> aurora.plot_pec(trs[(trs['lambda [A]'==584.4])])
```

I would definitely appreciate if reviewers could test these changes on a number of other ADF15 files. I've tried to make the new methods compatible with a number of ADF15 formats (yes, there are many...), but I may have missed something!

