### PR TITLE
fix to rescale n0 in ImpRad

### DIFF
--- a/aurora/core.py
+++ b/aurora/core.py
@@ -448,9 +448,13 @@ class aurora_sim:
             include_cx=self.namelist["cxr_flag"],
         )
 
+        # cache radiative & dielectronic recomb:
+        self.alpha_RDR_rates = Rne
+        
         if self.namelist["cxr_flag"]:
             # Get an effective recombination rate by summing radiative & CX recombination rates
-            Rne += cxne * (self._n0 / self._ne)[:, None]
+            self.alpha_CX_rates = cxne * (self._n0 / self._ne)[:, None]
+            Rne += self.alpha_CX_rates
 
         if self.namelist["nbi_cxr_flag"]:
             # include charge exchange between NBI neutrals and impurities

--- a/aurora/core.py
+++ b/aurora/core.py
@@ -451,10 +451,11 @@ class aurora_sim:
         # cache radiative & dielectronic recomb:
         self.alpha_RDR_rates = Rne
         
+        
         if self.namelist["cxr_flag"]:
             # Get an effective recombination rate by summing radiative & CX recombination rates
             self.alpha_CX_rates = cxne * (self._n0 / self._ne)[:, None]
-            Rne += self.alpha_CX_rates
+            Rne = Rne + self.alpha_CX_rates  #inplace addition would change also self.alpha_RDR_rates
 
         if self.namelist["nbi_cxr_flag"]:
             # include charge exchange between NBI neutrals and impurities


### PR DESCRIPTION
Quick fix for OMFIT ImpRad framework to freely rescale neutral density (n0) within inferences of impurity transport -- requested by @odstrcilt . 

mention @TGleiter 