### PR TITLE
Corrected bugs in the particle conservation

### DIFF
--- a/aurora/core.py
+++ b/aurora/core.py
@@ -1160,7 +1160,7 @@ class aurora_sim:
         # Compute total number of particles for particle conservation checks:
         all_particles = grids_utils.vol_int(
             total_impurity_density, self.rvol_grid, self.pro_grid, self.Raxis_cm,
-            rvol_max = self.rvol_lcfs
+            rvol_max = None
         )
 
         out["total"] = all_particles + (N_wall + N_div + N_pump + N_ret) * circ

--- a/aurora/main.f90
+++ b/aurora/main.f90
@@ -576,18 +576,17 @@ subroutine edge_model( &
   else
      tve = tve + (dsul + tsu) * det  ! no recycling, no divertor return
   endif
-
+  
   ! particles in divertor
   ! If recycling is on, particles from limiter and wall come back.
   ! Particles in divertor can only return (with rate given by N_div/taudiv) if rcl>=0
   if (rcl.ge.0) then  ! activated divertor return (rcl>=0) + recycling mode (if rcl>0)
      taustar = 1./(1./taudiv+1./taupump)    ! time scale for divertor depletion
      ff = .5*det/taustar
-     
-     divnew = ( divold*(1.-ff) + (dsu + src_div_t)*det )/(1.+ff)
   else
-     divnew = divold + (dsu+src_div_t)*det
+     ff = .5*det/taupump
   endif
+  divnew = ( divold*(1.-ff) + (dsu + src_div_t)*det )/(1.+ff)
 
   ! particles in pump
   npump = npump + .5*(divnew+divold)/taupump*det


### PR DESCRIPTION
Corrected bugs affecting the particle conservation:

- In **core.py**, in the calculation of the total number of impurity particles in the plasma, the volume integral should be extended over the entire radial grid and not only until the LCFS (i.e. using `rvol_max = None` rather than `rvol_max = asim.rvol_lcfs`) in order to really account for all the particles.
- In **main.f90** corrected a bug (present only when the recycling is deactivated), in the **edge_model** subroutine, which prevents the removal of particles from the divertor reservoir through pumping, leading to a continuous accumulation of particles in there.