### PR TITLE
Fix bug in plot_2d_overview in the OEDGE interface

### DIFF
--- a/aurora/oedge.py
+++ b/aurora/oedge.py
@@ -1204,7 +1204,7 @@ class oedge_output:
             label = self.name_maps[field]['label']
             units = self.name_maps[field]['units']
             
-            self.plot_2d(var, charge=charge, ax=ax, label=label+' '+units)
+            self.plot_2d(var, charge=charge, ax=ax, cbar_label=label+' '+units)
 
         plt.tight_layout()
 


### PR DESCRIPTION
The call to `oedge_output.plot_2d` in `oedge_output.plot_2d_overview` has the wrong keyword argument name for the colour bar label.
It was passing `label` instead of `cbar_label`, which throws an exception.