### PR TITLE
corrected error in calculation of neutral density from lyman-alpha

### DIFF
--- a/aurora/neutrals.py
+++ b/aurora/neutrals.py
@@ -460,7 +460,7 @@ def Lya_to_neut_dens(
         pec_recomb = 10 ** log10pec_dict[1215.2]["recom"].ev(np.log10(ne), np.log10(Te))
         pec_exc = 10 ** log10pec_dict[1215.2]["excit"].ev(np.log10(ne), np.log10(Te))
 
-        N1 = emiss_prof / E_21 / (ne * pec_exc + ni * pec_recomb)
+        N1 = ( ( emiss_prof / E_21 ) - (ni * ne * pec_recomb) ) / (ne * pec_exc)
 
     if plot:
         if rhop is None:


### PR DESCRIPTION
Small update in Lya_to_neut_dens which contained the wrong expression for N1 using the adas ADF15 rate coefficients. 

Previous expression
N1 = emiss_prof / E_21 / (ne * pec_exc + ni * pec_recomb)
change to 
N1 = ((emiss_prof / E_21)- ni * ne*pec_recomb) / (ne * pec_exc)

The overall effect of this error is small except in situations near the wall or diverter. 