### PR TITLE
Issue085 line shapes

### DIFF
--- a/aurora/__init__.py
+++ b/aurora/__init__.py
@@ -31,4 +31,6 @@ from .oedge import *
 
 from .facit import *
 
+from .line_broaden import *
+
 aurora_dir = os.path.dirname(os.path.abspath(__file__))

--- a/aurora/line_broaden.py
+++ b/aurora/line_broaden.py
@@ -838,7 +838,7 @@ def _get_2photon(
     '''
 
     # Tolerance on wavelength match
-    tol = 1e-4 # [AA]
+    tol = 1e-5 # [AA]
 
     # If searching for the transition by its wavelength
     if 'wavelength' in dphysics.keys():
@@ -857,7 +857,7 @@ def _get_2photon(
 
     # Error check
     if len(inds) == 0:
-        print('NO TRANSITION FOUND FOR LAMBDA= '+str(lmb))
+        print('NO TRANSITION FOUND FOR LAMBDA= '+str(wave_A))
         sys.exit(1)
 
     # Initializes output

--- a/aurora/line_broaden.py
+++ b/aurora/line_broaden.py
@@ -341,29 +341,27 @@ def _get_Voigt(
                     theta[tr,:],
                     FWHM[tr] 
                     ) = _calc_Voigt_scipy(
-                        FWHM_G = out_G['FWHM'][tr,:],
-                        FWHM_L = out_L['FWHM'][tr,:],
+                        FWHM_G = out_G['FWHM'][tr],
+                        FWHM_L = out_L['FWHM'][tr],
                         lambda0 = wave_A[tr]
                         )
 
             # Use pseudo-Voigt weighted sum function
             elif use_pseudo:
                 (
-                    lambs_profs_A[tr,:],
+                    lams_profs_A[tr,:],
                     theta[tr,:],
                     FWHM[tr]
                     ) = _calc_Voigt_pseudo(
-                        FWHM_G = out_G['FWHM'][tr,:],
+                        FWHM_G = out_G['FWHM'][tr],
                         lams_G = out_G['lams_profs_A'][tr,:],
                         theta_G = out_G['theta'][tr,:],
-                        FWHM_L = out_L['FWHM'][tr,:],
+                        FWHM_L = out_L['FWHM'][tr],
                         lams_L = out_L['lams_profs_A'][tr,:],
                         theta_L = out_L['theta'][tr,:],
                         lambda0 = wave_A[tr]
                         )
  
-    print('Voigt')
-    print(FWHM)
     # Output line shape and wavelength mesh
     return {
         'lams_profs_A': lams_profs_A,   # [AA], dim(trs,nlamb)
@@ -411,8 +409,6 @@ def _get_Doppler(
         wave_A=wave_A,
         )
 
-    print('Doppler')
-    print(FWHM)
     # Output line shape and wavelength mesh
     return {
         'lams_profs_A': lams_profs_A,   # [AA], dim(trs,nlamb)
@@ -513,8 +509,7 @@ def _get_Natural(
                 dnu = FWHM[ii],
                 wave_A=wave_A[ii],
                 )
-    print('Natural')
-    print(FWHM)
+    
     # Output line shape and wavelength mesh
     return {
         'lams_profs_A': lams_profs_A,   # [AA], dim(trs,nlamb)
@@ -651,6 +646,9 @@ def _calc_Voigt_scipy(
             +cnt.c*1e10/lambda0
             )
         ) # [AA]
+
+    # Ensure normalization
+    theta /= np.trapz(theta,mesh_A)
 
     # Output
     return mesh_A, theta, FWHM_V

--- a/aurora/line_broaden.py
+++ b/aurora/line_broaden.py
@@ -61,19 +61,17 @@ def get_line_broaden(
                 )
 
     # If only considering one broadening mech, skips convolution
-    #if len(dshape.keys()) == 1:
-    #    brd = list(dshape.keys())[0]
-    #    lams_profs_A = dshape[brd]['lams_profs_A'] # [AA], dim(trs,nlamb)
-    #    theta = dshape[brd]['theta'] # [1/AA], dim(trs,nlamb)
+    if len(dshape.keys()) == 1:
+        brd = list(dshape.keys())[0]
+        lams_profs_A = dshape[brd]['lams_profs_A'] # [AA], dim(trs,nlamb)
+        theta = dshape[brd]['theta'] # [1/AA], dim(trs,nlamb)
 
     # Convolutes line shapes
-    #else:
-    #    lams_profs_A, theta = _convolve(dshape=dshape) # dim(trs,nlamb)
+    else:
+        lams_profs_A, theta = _convolve(dshape=dshape) # dim(trs,nlamb)
 
-
-    #return line_shape
-
-    return dshape
+    # Output
+    return lams_profs_A, theta
 
 
 ########################################################
@@ -359,4 +357,44 @@ def _calc_Lorentzian(
     theta *= (cnt.c*1e10)/wave_A**2 # [1/AA]
 
     # Output
+    return lams_profs_A, theta
+
+########################################################
+#
+#             Utilities
+#
+#########################################################
+
+# Convolves together line profiles
+def _convolve(
+    dshape=None,
+    ):
+
+    # Broadening mechanisms
+    mechs = list(dshape.keys())
+
+    # Initializes output
+    lams_profs_A = np.zeros(dshape[mechs[0]]['lams_profs_A'].shape) # [AA], dim(trs, nlamb)
+    theta = np.zeros(dshape[mechs[0]]['lams_profs_A'].shape) # [1/AA], dim(trs,nlamb)
+
+    # Loop over transitions
+    for trs in np.arange(dshape[mechs[0]]['lams_profs_A'].shape[0]):
+        # Handling if Natural broadening wasn't included for this transition
+        mechs_tmp = mechs.copy()
+
+        if 'Natural' in mechs_tmp:
+            # Removes Natural broadening entry from consideration
+            if sum(dshape['Natural']['theta'][trs,:]) == 0:
+                mechs_tmp.remove('Natural')
+
+        # If now only one mechanism left
+        if len(mechs_tmp) == 1:
+            lams_profs_A[trs,:] = dshape[mechs_tmp[0]]['lams_prof_A'][trs,:]
+            theta[trs,:] = dshape[mechs_tmp[0]]['theta'][trs,:]
+
+        # Convolute if more than one mechanism
+        else:
+            blah = 0
+
+                
     return lams_profs_A, theta

--- a/aurora/line_broaden.py
+++ b/aurora/line_broaden.py
@@ -204,8 +204,29 @@ def _get_Instru(
     ):
     '''
     INPUTS: dphysics -- [dict], necessary physics information
-                i) 'Ti_eV' -- [float], [eV], local ion temperature
-                ii) 'ion_A' -- [float], [amu], species mass
+                i) 'width_A' -- [float], [AA], characteristic FWHM
+                                    on detector surface
+
+                NOTE: the philosophy here is that the user wishes to
+                quickly scope Instrumental broadening per a simple 
+                characteristic Gaussian spread model. 
+
+                i.e., if one considers a highly collimated, monoenergetic
+                beam of photons Bragg diffracted on a crystal spectrometer,
+                the reflected beam would be spread via the reflection curve
+                (rocking curve). We can therefore characterize instrumental 
+                broadening, assuming the rocking curve is a Gaussian, by the
+                arc length of a detection surface normal to the line-of-sight
+                subtended by the rocking curve FWHM. Therefore,
+                        width_A = omega_rc * L_cd
+
+                        where, omega_rc is the rocking curve FWHM in [rad],
+                        and L_cd is the distance between the crystal and 
+                        detector in [AA]
+
+                !!! To properly quantify instrumental broadening to account for
+                effects such as finite aperture size, defocusing, misalignment, etc.
+                it is heavily recommended to use a dedicated ray-tracing code
 
             wave_A -- [list], dim(trs,), [AA], 
                 transition central wavelength
@@ -219,6 +240,20 @@ def _get_Instru(
 
     '''
 
+    # Converts units of FWHM
+    dnu = dphysics['width_A'] * cnt.c*1e10 /wave_A**2 # [Hz], dim(trs,)
+
+    # Calculates general Gaussian shape
+    lams_profs_A, theta = _get_Gaussian(
+        dnu = dnu,
+        wave_A=wave_A,
+        )
+
+    # Output line shape and wavelength mesh
+    return {
+        'lams_profs_A': lams_profs_A,   # [AA], dim(trs,nlamb)
+        'theta': theta,                 # [1/AA], dim(trs,nlamb)
+        }
 
 
 ########################################################

--- a/aurora/line_broaden.py
+++ b/aurora/line_broaden.py
@@ -339,6 +339,13 @@ def _get_Natural(
     ):
     '''
     INPUTS: dphysics -- [dict], necessary physics information
+                i) 'key_options' -- [string], defines how Einstein
+                    coefficient data is indexed
+                    options: 'wavelegth', 'isel'
+                ii) rest of the keys are assumed to relate a float
+                    for the Einstein coefficient to the transition 
+
+                If 'key_options' == 'wavelength'  -->   
                 NOTE: The expected form is keys for each central
                 wavelength of interst with its associated Einstein
                 coefficient as a float. This is so that a user won't
@@ -385,11 +392,20 @@ def _get_Natural(
 
     # Loop over transitions of interest
     for lmb in dphysics.keys():
-        # Finds transitions of interst in ADF15 file
-        ind = np.where(
-            (wave_A >= float(lmb) -tol)
-            & (wave_A <= float(lmb)+tol)
-            )[0]
+        # Error check
+        if lmb == 'key_options':
+            continue
+
+        # If transition defined by central wavelength
+        if dphysics['key_options'] == 'wavelength':
+            # Finds transitions of interst in ADF15 file
+            ind = np.where(
+                (wave_A >= float(lmb) -tol)
+                & (wave_A <= float(lmb)+tol)
+                )[0]
+        # If transition defined by isel index within ADF15 file
+        elif dphysics['key_options'] == 'isel':
+            ind = int(float(lmb) - 1)
 
         # Error check
         if len(ind) == 0:

--- a/aurora/line_broaden.py
+++ b/aurora/line_broaden.py
@@ -1,0 +1,97 @@
+'''
+
+line_shape.py is a module that manages line radiation
+broadening physics one wishes to include
+
+cjperks
+Aug. 04, 2023
+
+'''
+
+# Modules
+import numpy as np
+from scipy.constants import e, m_p, c
+
+__all__ = [
+    'get_line_broaden',
+    ]
+
+
+
+########################################################
+#
+#                   Main
+#
+#########################################################
+
+def get_line_broaden(
+    dbroad=None,
+    ):
+
+    # Various physics options
+    if 'Doppler' in dbroad.keys():
+        line_shape = _get_Doppler(
+            Ti_eV=None,
+            )
+
+   
+    return line_shape
+
+
+########################################################
+#
+#                   Utilities
+#
+#########################################################
+
+def _get_Doppler(
+    Ti_eV=None.
+    ):
+
+     # Doppler broadening
+    mass = constants.m_p * ion_A
+    dnu_g = (
+        np.sqrt(2.0 * (Ti_eV * constants.e) / mass)
+        * (constants.c / wave_A)
+        / constants.c
+    )
+
+    # set a variable delta lambda based on the width of the broadening
+    _dlam_A = wave_A**2 / constants.c * dnu_g * 5  # 5 standard deviations
+
+    lams_profs_A = np.linspace(wave_A - _dlam_A, wave_A + _dlam_A, 100, axis=1)
+
+    # Gaussian profiles of the lines
+    theta = np.exp(
+        -(((constants.c / lams_profs_A - c / wave_A[:, None]) / dnu_g[:, None]) ** 2)
+    )
+
+    # Normalize Gaussian profile
+    theta /= np.sqrt(np.pi) * dnu_g[:, None] * wave_A[:, None] ** 2 / constants.c
+
+    # non-equally spaced wavelenght
+    wave_final_A = np.unique(lams_profs_A)
+
+    if (plot_all_lines or plot_spec_tot) and ax is None:
+        fig, ax = plt.subplots()
+
+    # contributions to spectrum
+    spec = {}
+    spec_tot = np.zeros_like(wave_final_A)
+    colors = {"ioniz": "r", "excit": "b", "recom": "g", "drsat": "m", "chexc": "c"}
+    for ii in np.arange(lams_profs_A.shape[0]):
+        line_shape = interp1d(
+            lams_profs_A[ii], theta[ii], bounds_error=False, fill_value=0.0
+        )(wave_final_A)
+        for typ, intens in line_emiss[ii].items():
+            comp = intens * line_shape
+            if typ not in spec:
+                spec[typ] = np.zeros_like(comp)
+
+            if plot_all_lines and intens > np.max([l[typ] for l in line_emiss]) / 1000:
+                ax.plot(lams_profs_A[ii] + dlam_A, intens * theta[ii], c=colors[typ])
+
+            spec[typ] += comp
+            spec_tot += comp
+
+    return line_shape

--- a/aurora/line_broaden.py
+++ b/aurora/line_broaden.py
@@ -788,7 +788,7 @@ def _get_2photon(
     theta = np.zeros((len(inds),nlamb))# [1/AA], dim(ntrs,nlamb)
 
     # Fit grid, [], dim(nlamb,)
-    y_grid = np.linspace(0.01, 0.99, nlamb)
+    y_grid = np.linspace(0.99, 0.01, int(nlamb-1))
 
     # Loop over transitions
     for ind_t, ind_y in enumerate(inds):
@@ -809,6 +809,10 @@ def _get_2photon(
                 lamb0 = wave_A[ind_y],
                 y_grid = y_grid,
                 ) # [AA], [1/AA], dim(nlmabda,)
+
+        # Adds bound at lambda = lambda_0
+        np.insert(lams_profs_A[ind_t,:], 0, wave_ind[ind_y])
+        np.insert(theta[ind_t,:], 0, 0)
 
         # Error check
         else:

--- a/aurora/line_broaden.py
+++ b/aurora/line_broaden.py
@@ -99,7 +99,7 @@ def _get_Doppler(
         np.sqrt(2.0 * (dphysics['Ti_eV'] * cnt.e) / mass)
         / cnt. c
         * (cnt.c / wave_A)
-        ) # [Hz], dim(trs,)
+        ) # [m/AA * Hz], dim(trs,)
 
     # set a variable delta lambda based on the width of the broadening
     _dlam_A = wave_A**2 / cnt.c * dnu_g * 5  # [AA], dim(trs,), 5 standard deviations
@@ -157,3 +157,103 @@ def _get_Doppler(
     #        spec_tot += comp
     #
     #return line_shape
+
+def _get_Natural(
+    # Settings
+    dphysics=None,
+    # ADF15 file
+    wave_A=None,
+    ):
+    '''
+    INPUTS: dphysics -- [dict], necessary physics information
+                NOTE: The expected form is keys for each central
+                wavelength of interst with its associated Einstein
+                coefficient as a float. This is so that a user won't
+                need to provide a data for every transition in the
+                ADF15 file.
+
+                !!! It is assumed you know, at least very closely,
+                the exact wavelength stored in your ADF15 file
+
+                i.e., If one wishes to explore the impact of Natural
+                broadening on the w, x, y, z lines for He-like Kr, the
+                input dictionary would look like --
+                dphysics = {
+                    '0.9454': 1.529e15, # [1/s], w line
+                    '0.9471': 9.327e10, # [1/s], x line
+                    '0.9518': 3.945e14, # [1/s], y line
+                    '0.9552': 5.715e9,  # [1/s], z line
+                    }
+
+            wave_A -- [list], dim(trs,), [AA], 
+                transition central wavelength
+
+    OUTPUTS: [dict], line shape
+                i) 'lam_profs_A' -- [AA], dim(trs,nlamb), 
+                        wavelength mesh for each transition
+                ii) 'theta' -- [1/AA], dim(trs, nlamb),
+                        line shape for each transition
+
+
+    '''
+
+    # Initializes output
+    lams_profs_A = np.zeros((len(wave_A), 100)) # [AA], dim(trs, nlamb)
+    theta = np.zeros((len(wave_A), 100)) # [1/AA], dim(trs, nlamb)
+
+    # Tolerance on wavelength match
+    tol = 1e-4 # [AA]
+
+    # Loop over transitions of interest
+    for lmb in dphysics.keys():
+        # Finds transitions of interst in ADF15 file
+        ind = np.where(
+            (wave_A >= lmb -tol)
+            & (wave_A <= lamb+tol)
+            )[0]
+
+        # Error check
+        if len(ind) == 0:
+            print('NO TRANSITION FOUND FOR LAMBDA= '+str(lmb))
+            continue
+
+        # Characteristic time for transitions
+        tau = 2/dphysics[lmb] # [s]
+
+        # FWHM
+        dnu = 1/(np.pi*tau) # [Hz]
+
+        # Loop over transitions
+        for ii in ind:
+            # set a variable delta lambda based on the width of the broadening
+            _dlam_A = (
+                wave_A[ii]**2 / (cnt.c*1e10) 
+                * dnu * 5  
+                )# [AA], dim(trs,), 5 standard deviations
+
+            # Wavelength mesh
+            lams_profs_A[ii,:] = np.linspace(
+                wave_A[ii] - _dlam_A, 
+                wave_A[ii] + _dlam_A, 
+                100) # [AA], dim(,nlamb)
+
+            # Lorentz profile
+            theta[ii,:] = 1/(
+                1+ (
+                    (1/lam_profs_A[ii,:] - 1/ wave_A[ii])
+                    * cnt.c*1e10
+                    * 2*np.pi*tau
+                    )**2
+                ) # [], dim(,nlamb)
+                
+            # Normalization
+            theta[ii,:] *= 2* tau # [1/Hz]
+
+            # Fixes units
+            theta[ii,:] *= (cnt.c*1e10)/wave_A[ii]**2 # [1/AA]
+
+    # Output line shape and wavelength mesh
+    return {
+        'lams_profs_A': lams_profs_A,   # [AA], dim(trs,nlamb)
+        'theta': theta,                 # [1/AA], dim(trs,nlamb)
+        }

--- a/aurora/line_broaden.py
+++ b/aurora/line_broaden.py
@@ -80,7 +80,7 @@ def get_line_broaden(
         lams_profs_A, theta = _convolve(dshape=dshape) # dim(trs,nlamb)
 
     # Output
-    return lams_profs_A, theta, dshape
+    return lams_profs_A, theta
 
 
 ########################################################

--- a/aurora/line_broaden.py
+++ b/aurora/line_broaden.py
@@ -10,7 +10,7 @@ Aug. 04, 2023
 
 # Modules
 import numpy as np
-from scipy.constants import e, m_p, c
+import scipy.constants as cnt
 
 __all__ = [
     'get_line_broaden',
@@ -25,14 +25,40 @@ __all__ = [
 #########################################################
 
 def get_line_broaden(
-    dbroad=None,
+    # Settings
+    dbroad=None,        # Dictionary storing various broadening mechs
+    # ADF15 file
+    wave_A=None,        # [AA], dim(trs,), central wavelengths
     ):
 
-    # Various physics options
-    if 'Doppler' in dbroad.keys():
-        line_shape = _get_Doppler(
-            Ti_eV=None,
-            )
+    # Initializes ouput
+    line_shape = 0
+
+    # Initializes storage
+    dshape = {}
+
+    # Loop over various physics options
+    for brd in dbroad.keys():
+        # If one wishes to include Doppler broadening
+        if brd == ' Doppler':
+            dshape[brd] = _get_Doppler(
+                dphysics=dbroad[brd],
+                wave_A=wave_A,
+                )
+
+        # If one wishes to inlcude Natural broadening
+        elif brd == 'Natural':
+            dshape[brd] = _get_Natural(
+                dphysics=dbroad[brd],
+                wave_A=wave_A,
+                )
+
+        # If one wishes to include Instrumental broadening
+        elif brd == 'Instrumental':
+            dshape[brd] = _get_Instru(
+                dphyscis=dbroad[brd],
+                wave_A=wave_A,
+                )
 
    
     return line_shape
@@ -45,53 +71,89 @@ def get_line_broaden(
 #########################################################
 
 def _get_Doppler(
-    Ti_eV=None.
+    # Settings
+    dpyhsics=None,         # Dictionary of neccessary phyiscs
+    # ADF15 file
+    wave_A=None,
     ):
+    '''
+    INPUTS: dphysics -- [dict], necessary physics information
+                i) 'Ti_eV' -- [float], [eV], local ion temperature
+                ii) 'ion_A' -- [float], [amu], species mass
 
-     # Doppler broadening
-    mass = constants.m_p * ion_A
+            wave_A -- [list], dim(trs,), [AA], 
+                transition central wavelength
+
+    OUTPUTS: [dict], line shape
+                i) 'lam_profs_A' -- [AA], dim(trs,nlamb), 
+                        wavelength mesh for each transition
+                ii) 'theta' -- [1/AA], dim(trs, nlamb),
+                        line shape for each transition
+
+
+    '''
+
+     # Doppler broadening FWHM
+    mass = cnt.m_p * dphysics['ion_A'] # [kg]
     dnu_g = (
-        np.sqrt(2.0 * (Ti_eV * constants.e) / mass)
-        * (constants.c / wave_A)
-        / constants.c
-    )
+        np.sqrt(2.0 * (dphysics['Ti_eV'] * cnt.e) / mass)
+        / cnt. c
+        * (cnt.c / wave_A)
+        ) # [Hz], dim(trs,)
 
     # set a variable delta lambda based on the width of the broadening
-    _dlam_A = wave_A**2 / constants.c * dnu_g * 5  # 5 standard deviations
+    _dlam_A = wave_A**2 / cnt.c * dnu_g * 5  # [AA], dim(trs,), 5 standard deviations
 
-    lams_profs_A = np.linspace(wave_A - _dlam_A, wave_A + _dlam_A, 100, axis=1)
+    # Wavelength mesh
+    lams_profs_A = np.linspace(
+        wave_A - _dlam_A, 
+        wave_A + _dlam_A, 
+        100, axis=1) # [AA], dim(trs, nlamb)
 
     # Gaussian profiles of the lines
     theta = np.exp(
-        -(((constants.c / lams_profs_A - c / wave_A[:, None]) / dnu_g[:, None]) ** 2)
-    )
+        -(
+            ((cnt.c / lams_profs_A - cnt.c / wave_A[:, None]) 
+            / dnu_g[:, None]) ** 2
+            )
+        ) # [], dim(trs, nlamb)
 
     # Normalize Gaussian profile
-    theta /= np.sqrt(np.pi) * dnu_g[:, None] * wave_A[:, None] ** 2 / constants.c
+    theta /= (
+        np.sqrt(np.pi) * dnu_g[:, None] 
+        * wave_A[:, None] ** 2 / cnt.c
+        ) # [1/AA], dim(trs,nlamb)
+
+    # Output line shape and wavelength mesh
+    return {
+        'lams_profs_A': lams_profs_A,   # [AA], dim(trs,nlamb)
+        'theta': theta,                 # [1/AA], dim(trs,nlamb)
+        }
+
 
     # non-equally spaced wavelenght
-    wave_final_A = np.unique(lams_profs_A)
+    #wave_final_A = np.unique(lams_profs_A)
 
-    if (plot_all_lines or plot_spec_tot) and ax is None:
-        fig, ax = plt.subplots()
+    #if (plot_all_lines or plot_spec_tot) and ax is None:
+    #    fig, ax = plt.subplots()
 
     # contributions to spectrum
-    spec = {}
-    spec_tot = np.zeros_like(wave_final_A)
-    colors = {"ioniz": "r", "excit": "b", "recom": "g", "drsat": "m", "chexc": "c"}
-    for ii in np.arange(lams_profs_A.shape[0]):
-        line_shape = interp1d(
-            lams_profs_A[ii], theta[ii], bounds_error=False, fill_value=0.0
-        )(wave_final_A)
-        for typ, intens in line_emiss[ii].items():
-            comp = intens * line_shape
-            if typ not in spec:
-                spec[typ] = np.zeros_like(comp)
-
-            if plot_all_lines and intens > np.max([l[typ] for l in line_emiss]) / 1000:
-                ax.plot(lams_profs_A[ii] + dlam_A, intens * theta[ii], c=colors[typ])
-
-            spec[typ] += comp
-            spec_tot += comp
-
-    return line_shape
+    #spec = {}
+    #spec_tot = np.zeros_like(wave_final_A)
+    #colors = {"ioniz": "r", "excit": "b", "recom": "g", "drsat": "m", "chexc": "c"}
+    #for ii in np.arange(lams_profs_A.shape[0]):
+    #    line_shape = interp1d(
+    #        lams_profs_A[ii], theta[ii], bounds_error=False, fill_value=0.0
+    #    )(wave_final_A)
+    #    for typ, intens in line_emiss[ii].items():
+    #        comp = intens * line_shape
+    #        if typ not in spec:
+    #            spec[typ] = np.zeros_like(comp)
+    #
+    #        if plot_all_lines and intens > np.max([l[typ] for l in line_emiss]) / 1000:
+    #            ax.plot(lams_profs_A[ii] + dlam_A, intens * theta[ii], c=colors[typ])
+    #
+    #        spec[typ] += comp
+    #        spec_tot += comp
+    #
+    #return line_shape

--- a/aurora/line_broaden.py
+++ b/aurora/line_broaden.py
@@ -18,7 +18,8 @@ __all__ = [
     'get_line_broaden',
     ]
 
-
+# Number of wavelength mesh points
+nlamb=101
 
 ########################################################
 #
@@ -220,6 +221,9 @@ def _get_pVoigt(
                 broadening on the w, x, y, z lines for He-like Kr, the
                 input dictionary would look like --
                 dphysics = {
+                    'Ti_eV': 10e3,
+                    'ion_A': 83.798,
+                    'key_options': 'wavelength',
                     '0.9454': 1.529e15, # [Hz], w line
                     '0.9471': 9.327e10, # [Hz], x line
                     '0.9518': 3.945e14, # [Hz], y line
@@ -415,6 +419,7 @@ def _get_Natural(
                 broadening on the w, x, y, z lines for He-like Kr, the
                 input dictionary would look like --
                 dphysics = {
+                    'key_options': 'wavelength,
                     '0.9454': 1.529e15, # [1/s], w line
                     '0.9471': 9.327e10, # [1/s], x line
                     '0.9518': 3.945e14, # [1/s], y line
@@ -439,8 +444,8 @@ def _get_Natural(
     '''
 
     # Initializes output
-    lams_profs_A = np.zeros((len(wave_A), 101)) # [AA], dim(trs, nlamb)
-    theta = np.zeros((len(wave_A), 101)) # [1/AA], dim(trs, nlamb)
+    lams_profs_A = np.zeros((len(wave_A), nlamb)) # [AA], dim(trs, nlamb)
+    theta = np.zeros((len(wave_A), nlamb)) # [1/AA], dim(trs, nlamb)
     FWHM = np.zeros((len(wave_A))) # [Hz]
 
     # Tolerance on wavelength match
@@ -449,7 +454,7 @@ def _get_Natural(
     # Loop over transitions of interest
     for lmb in dphysics.keys():
         # Error check
-        if lmb == 'key_options':
+        if lmb in ['key_options', 'Ti_eV', 'ion_A']:
             continue
 
         # If transition defined by central wavelength
@@ -461,7 +466,7 @@ def _get_Natural(
                 )[0]
         # If transition defined by isel index within ADF15 file
         elif dphysics['key_options'] == 'isel':
-            ind = int(float(lmb) - 1)
+            ind = [int(float(lmb) -1)]
 
         # Error check
         if len(ind) == 0:
@@ -580,7 +585,6 @@ def _calc_Gaussian(
     dnu = None, # [Hz], [float], variance
     wave_A=None, # [AA], dim(trs,), central wavelength
     # Wavelength mesh controls
-    nlamb=101, # [scalar], number of wavelength points
     nstd = 5,    # number of standard deviations in wavelength mesh
     ):
     '''
@@ -627,7 +631,6 @@ def _calc_Lorentzian(
     dnu = None, # [Hz], [float], FWHM
     wave_A=None, # [AA], [float], central wavelength
     # Wavelength mesh controls
-    nlamb=101,  # number of wavelength points
     nstd = 20, # number of standard deviations in wavelength mesh
     ):
     '''

--- a/aurora/line_broaden.py
+++ b/aurora/line_broaden.py
@@ -66,10 +66,11 @@ def get_line_broaden(
 
 ########################################################
 #
-#                   Utilities
+#             Broadening Mechanisms
 #
 #########################################################
 
+# Calculates Doppler broadening
 def _get_Doppler(
     # Settings
     dpyhsics=None,         # Dictionary of neccessary phyiscs
@@ -93,36 +94,19 @@ def _get_Doppler(
 
     '''
 
-     # Doppler broadening FWHM
+    # Doppler broadening FWHM
     mass = cnt.m_p * dphysics['ion_A'] # [kg]
-    dnu_g = (
+    dnu = (
         np.sqrt(2.0 * (dphysics['Ti_eV'] * cnt.e) / mass)
         / cnt. c
-        * (cnt.c / wave_A)
-        ) # [m/AA * Hz], dim(trs,)
+        * (cnt.c*1e10 / wave_A)
+        ) # [Hz], dim(trs,)
 
-    # set a variable delta lambda based on the width of the broadening
-    _dlam_A = wave_A**2 / cnt.c * dnu_g * 5  # [AA], dim(trs,), 5 standard deviations
-
-    # Wavelength mesh
-    lams_profs_A = np.linspace(
-        wave_A - _dlam_A, 
-        wave_A + _dlam_A, 
-        100, axis=1) # [AA], dim(trs, nlamb)
-
-    # Gaussian profiles of the lines
-    theta = np.exp(
-        -(
-            ((cnt.c / lams_profs_A - cnt.c / wave_A[:, None]) 
-            / dnu_g[:, None]) ** 2
-            )
-        ) # [], dim(trs, nlamb)
-
-    # Normalize Gaussian profile
-    theta /= (
-        np.sqrt(np.pi) * dnu_g[:, None] 
-        * wave_A[:, None] ** 2 / cnt.c
-        ) # [1/AA], dim(trs,nlamb)
+    # Calculates general Gaussian shape
+    lams_profs_A, theta = _get_Gaussian(
+        dnu = dnu,
+        wave_A=wave_A,
+        )
 
     # Output line shape and wavelength mesh
     return {
@@ -130,34 +114,7 @@ def _get_Doppler(
         'theta': theta,                 # [1/AA], dim(trs,nlamb)
         }
 
-
-    # non-equally spaced wavelenght
-    #wave_final_A = np.unique(lams_profs_A)
-
-    #if (plot_all_lines or plot_spec_tot) and ax is None:
-    #    fig, ax = plt.subplots()
-
-    # contributions to spectrum
-    #spec = {}
-    #spec_tot = np.zeros_like(wave_final_A)
-    #colors = {"ioniz": "r", "excit": "b", "recom": "g", "drsat": "m", "chexc": "c"}
-    #for ii in np.arange(lams_profs_A.shape[0]):
-    #    line_shape = interp1d(
-    #        lams_profs_A[ii], theta[ii], bounds_error=False, fill_value=0.0
-    #    )(wave_final_A)
-    #    for typ, intens in line_emiss[ii].items():
-    #        comp = intens * line_shape
-    #        if typ not in spec:
-    #            spec[typ] = np.zeros_like(comp)
-    #
-    #        if plot_all_lines and intens > np.max([l[typ] for l in line_emiss]) / 1000:
-    #            ax.plot(lams_profs_A[ii] + dlam_A, intens * theta[ii], c=colors[typ])
-    #
-    #        spec[typ] += comp
-    #        spec_tot += comp
-    #
-    #return line_shape
-
+# Calculates Natural broadening
 def _get_Natural(
     # Settings
     dphysics=None,
@@ -184,6 +141,7 @@ def _get_Natural(
                     '0.9518': 3.945e14, # [1/s], y line
                     '0.9552': 5.715e9,  # [1/s], z line
                     }
+                    ref: K.M. Aggarwal and F.P. Keenan, 2012 Phys. Scr. 86 035302
 
             wave_A -- [list], dim(trs,), [AA], 
                 transition central wavelength
@@ -225,35 +183,133 @@ def _get_Natural(
 
         # Loop over transitions
         for ii in ind:
-            # set a variable delta lambda based on the width of the broadening
-            _dlam_A = (
-                wave_A[ii]**2 / (cnt.c*1e10) 
-                * dnu * 5  
-                )# [AA], dim(trs,), 5 standard deviations
-
-            # Wavelength mesh
-            lams_profs_A[ii,:] = np.linspace(
-                wave_A[ii] - _dlam_A, 
-                wave_A[ii] + _dlam_A, 
-                100) # [AA], dim(,nlamb)
-
-            # Lorentz profile
-            theta[ii,:] = 1/(
-                1+ (
-                    (1/lam_profs_A[ii,:] - 1/ wave_A[ii])
-                    * cnt.c*1e10
-                    * 2*np.pi*tau
-                    )**2
-                ) # [], dim(,nlamb)
-                
-            # Normalization
-            theta[ii,:] *= 2* tau # [1/Hz]
-
-            # Fixes units
-            theta[ii,:] *= (cnt.c*1e10)/wave_A[ii]**2 # [1/AA]
+            # Calculate Lorentzian shape
+            lams_profs_A[ii,:], theta[ii,:] = _get_Lorentzian(
+                dnu = dnu,
+                wave_A=wave_A[ii],
+                )
 
     # Output line shape and wavelength mesh
     return {
         'lams_profs_A': lams_profs_A,   # [AA], dim(trs,nlamb)
         'theta': theta,                 # [1/AA], dim(trs,nlamb)
         }
+
+# Calculates Instrumental broadening
+def _get_Instru(
+    # Settings
+    dpyhsics=None,         # Dictionary of neccessary phyiscs
+    # ADF15 file
+    wave_A=None,
+    ):
+    '''
+    INPUTS: dphysics -- [dict], necessary physics information
+                i) 'Ti_eV' -- [float], [eV], local ion temperature
+                ii) 'ion_A' -- [float], [amu], species mass
+
+            wave_A -- [list], dim(trs,), [AA], 
+                transition central wavelength
+
+    OUTPUTS: [dict], line shape
+                i) 'lam_profs_A' -- [AA], dim(trs,nlamb), 
+                        wavelength mesh for each transition
+                ii) 'theta' -- [1/AA], dim(trs, nlamb),
+                        line shape for each transition
+
+
+    '''
+
+
+
+########################################################
+#
+#             Line Shapes
+#
+#########################################################
+
+# General Gaussian shape calculator
+def _calc_Gaussian(
+    dnu = None, # [Hz], [float], FWHM
+    wave_A=None, # [AA], dim(trs,), central wavelength
+    ):
+    '''
+    Note this function is meant to be a general-purpose 
+    Gaussian shape calculator to use when considering
+        1) Doppler broadening
+        2) Suprathermal ions
+        3) Instrumental broadening
+
+    '''
+
+    # set a variable delta lambda based on the width of the broadening
+    _dlam_A = (
+        wave_A**2 / (cnt.c*1e10) 
+        * dnu * 5
+        )  # [AA], dim(trs,), 5 standard deviations
+
+    # Wavelength mesh
+    lams_profs_A = np.linspace(
+        wave_A - _dlam_A, 
+        wave_A + _dlam_A, 
+        100, axis=1) # [AA], dim(trs, nlamb)
+
+    # Gaussian profiles of the lines
+    theta = np.exp(
+        -(
+            ((1 / lams_profs_A - 1 / wave_A[:, None])
+            *cnt.c *1e10
+            / dnu[:, None]) ** 2
+            )
+        ) # [], dim(trs, nlamb)
+
+    # Normalize Gaussian profile
+    theta /= (
+        np.sqrt(np.pi) * dnu[:, None] 
+        * wave_A[:, None] ** 2 / (cnt.c*1e10)
+        ) # [1/AA], dim(trs,nlamb)
+
+    # Output
+    return lams_profs_A, theta
+
+# General Lorentzian shape calculator
+def _calc_Lorentzian(
+    dnu = None, # [Hz], [float], FWHM
+    wave_A=None, # [AA], [float], central wavelength
+    ):
+    '''
+    Note this function is meant to be a general-purpose 
+    Lorentzian shape calculator to use when considering
+        1) Natural broadening
+        2) Pressure broadening
+
+    '''
+
+    # set a variable delta lambda based on the width of the broadening
+    _dlam_A = (
+        wave_A**2 / (cnt.c*1e10) 
+        * dnu * 5  
+        )# [AA], dim(trs,), 5 standard deviations
+
+    # Wavelength mesh
+    lams_profs_A = np.linspace(
+        wave_A - _dlam_A, 
+        wave_A + _dlam_A, 
+        100) # [AA], dim(,nlamb)
+
+    # Lorentz profile
+    theta = 1/(
+        1+ (
+            (1/lam_profs_A - 1/ wave_A)
+            * cnt.c*1e10
+            * 2 / dnu
+            )**2
+        ) # [], dim(,nlamb)
+                
+    # Normalization
+    theta *= 2 / (np.pi * dnu) # [1/Hz]
+
+    # Fixes units
+    theta *= (cnt.c*1e10)/wave_A**2 # [1/AA]
+
+    # Output
+    return lams_profs_A, theta

--- a/aurora/line_broaden.py
+++ b/aurora/line_broaden.py
@@ -371,6 +371,14 @@ def _calc_Lorentzian(
 def _convolve(
     dshape=None,
     ):
+    '''
+    NOTE: THis function has been benchmarked 
+    against analytic euqations for 
+        i) Gaussian * Delta function
+        ii) Gaussian * Gaussian
+    to a <1% error
+
+    '''
 
     # Broadening mechanisms
     mechs = list(dshape.keys())

--- a/aurora/neutrals.py
+++ b/aurora/neutrals.py
@@ -457,8 +457,10 @@ def Lya_to_neut_dens(
         log10pec_dict = radiation.read_adf15(path)  # , plot_lines=[1215.2])
 
         # evaluate these interpolations on our profiles
-        pec_recomb = 10 ** log10pec_dict[1215.2]["recom"].ev(np.log10(ne), np.log10(Te))
-        pec_exc = 10 ** log10pec_dict[1215.2]["excit"].ev(np.log10(ne), np.log10(Te))
+        rec_idx = np.where( (log10pec_dict['lambda [A]'] == 1215.2) & (log10pec_dict['type'] == 'recom'))[0][0]
+        excit_idx = np.where( (log10pec_dict['lambda [A]'] == 1215.2) & (log10pec_dict['type'] == 'excit'))[0][0]
+        pec_recomb = 10 ** log10pec_dict['log10 PEC fun'][rec_idx].ev(np.log10(ne), np.log10(Te))
+        pec_exc = 10 ** log10pec_dict['log10 PEC fun'][excit_idx].ev(np.log10(ne), np.log10(Te))
 
         N1 = ( ( emiss_prof / E_21 ) - (ni * ne * pec_recomb) ) / (ne * pec_exc)
 


### PR DESCRIPTION
### What's New

- New module `line_broaden` to manage various line broadening mechanisms a user can toggle on\off
     - At the lowest level, there's generalized Gaussian and Lorentzian line shape calculators that takes as input the frequency FWHM (in units Hz) from some model that then outputs the line shape (in units 1/AA) on wavelength mesh centered on the transition wavelength stored in the ADF15 file
     - At a higher level, there's models for the FWHM due to Doppler, Natural, and Instrumental broadening
         - Allowed flexibility if other broadening models are added later per other applications: Pressure, Stark, etc.
     - There is also a model to include suprathermal ion wings per a Bi-Maxwellian model
          - NOTE: It is assumed that the user won't turn on the `Doppler` and `Suprathermal_Ions` options at the same time
          - Maybe in the future this function could be generalized to arbitrary distribution functions, but the philosophy employed right now is simple scoping tools
     - At the highest level, `aurora.line_broaden.get_line_broaden()` accepts from `aurora.radiation.get_local_spectrum()` an array of transition wavelengths and a dictionary, `dbroad`, whose keys are the various broadening mechanisms of interest and whose entries are the necessary physics for the associated model
     - Given many broadening mechanisms at once, the profiles are then convoluted together
- NOTE: care was taken to adjust the wavelength mesh to ensure the outputted normalized line shape was resolved well enough to integrate to 1 while ensuring the mesh wasn't ridiculously large (i.e. Lorentzians, Suprathermal ions)

### Using Doppler Broadening

- To not perturb other people's workflow, when `aurora.radiation.get_local_spectrum(dbroad=None)` then it is assumed you just want Doppler broadening so everything runs the same as before

### Using Instrumental Broadening

- What's employed here is a very simplified Gaussian model for Instrumental broadening. Ray-tracing is necessary to do it right, but this is meant to be a quick scoping tool
       -  What the user gives is the Gaussian FWHM in units [\AA]
       - NOTE: It's pretty obvious how the inputs of this option can be leveraged to include any Gaussian broadening from some external model
- What is assumed for the model is that one has a detector surface with an associated wavelength mesh and they know from a monochromatic light source the characteristic pixel spread in the spectral direction 
     - i.e., if one is using a crystal spectrometer, even with a highly collimated light source, there's an approximately Gaussian distribution about the Bragg angle that light can be reflected (the rocking curve)
     - So one can characterize the resultant pixel spread as the characteristic arc length of the rocking curve projected onto the detector surface (rocking curve FHWM * crystal-to-detector distance) divided by the detector width
     - To convert this into [AA], then multiply by the spectral range
  - In generality, what is needed is the spectral range times the characteristic fraction of pixels illuminated by the Gaussian spread, so in units [AA]
 - NOTE:  Since the model for Doppler and Instrumental broadening are both Gaussian, the convolution of the two has been benchmarked against the analytic expression to good agreement
       - <img width="592" alt="Screenshot 2023-08-08 at 10 29 54 AM" src="https://github.com/fsciortino/Aurora/assets/71457911/b34f0b8f-430f-441c-82b2-cf275e7a2c67">
       - The blue curve (analytic) is behind the red curve (computed)


Minimum working code (simulating He-like Kr): 
```
import aurora
import os

# Inputs
adf15_file = os.path.join(
    '/home/cjperks/tofu_sparc/atomic_data/ADAS_PEC_files',
    'Krypton',
    'fs#0.50A_8.50A#kr34.dat'
    )
Te_eV = Ti_eV = 3e3
ne_cm3 = 1e14

dbroad = {
    'Doppler':{
        'Ti_eV': Ti_eV, # [eV]
        'ion_A': 83.8, # [amu]; Kr
        },
    'Instrumental':{
        'width_A': 11e-3 * (2.05e-4 * 290/3.84), # [AA]; spec_rng * (rc_FWHM * D_cd / w_d)
        },
    }

out = aurora.get_local_spectrum(
    adf15_file,
    ne_cm3,
    Te_eV,
    ion_exc_rec_dens=[0,1,0],
    Ti_eV=Ti_eV,
    n0_cm3=0.0,
    dlam_A=0.0,
    plot_spec_tot=False,
    dbroad=dbroad,
    )
```

### Using Natural Broadening

- To include this, you need the Einstein coefficient for every transition of interest which can be hard to come by
     - So the philosophy employed here is that each entry in the `dbroad['Natural']` dictionary is a transition wavelength (hopefully you've read your ADF15 file) with it's associated Einstein coefficient
     - NOTE: It's pretty obvious how the inputs of this option can be leveraged to include any Lorentzian broadening from some external model 
     - There's a tolerance of 1e-4 AA in the case a user gets their transition wavelengths from some other resource (calculated, NIST, etc.) Hopefully small enough that you don't jump to a different line
     - If one has an ADF15 file with multiple entries for the same wavelength, but different population mechanisms (ion, exc, rec) then all are captured here
- The convolution calculator is able to handle the difference between lines that weren't Naturally broadened and ones that were
    - NOTE: If Natural broadening was the only line mechanism turned on then all other lines are zeroed out as the line shape data is initialized as all zeros
- This workflow has been benchmarked with convoluting Doppler broadening in the limit the Einstein coefficient is very small so the Lorentzian becomes a Delta function
    - <img width="587" alt="Screenshot 2023-08-08 at 10 49 29 AM" src="https://github.com/fsciortino/Aurora/assets/71457911/7615e329-2ccd-4b3e-aae0-2e41e51acaae">

Minimum working code (simulating He-like Kr):
```
import aurora
import os

# Inputs
adf15_file = os.path.join(
    '/home/cjperks/tofu_sparc/atomic_data/ADAS_PEC_files',
    'Krypton',
    'fs#0.50A_8.50A#kr34.dat'
    )
Te_eV = Ti_eV = 3e3
ne_cm3 = 1e14

dbroad = {
    'Doppler':{
        'Ti_eV': Ti_eV, # [eV]
        'ion_A': 83.8, # [amu]; Kr
        },
    'Natural':{
        '0.9454': 1.529e15, # [1/s]; w-line so the largest Einstein coefficient
        },
    }

out = aurora.get_local_spectrum(
    adf15_file,
    ne_cm3,
    Te_eV,
    ion_exc_rec_dens=[0,1,0],
    Ti_eV=Ti_eV,
    n0_cm3=0.0,
    dlam_A=0.0,
    plot_spec_tot=False,
    dbroad=dbroad,
    )

```

### Using Suprathermal Ion

- Right now, there's just a Bi-Maxwellian model so it runs Doppler broadening twice but once for a slow population and another for a fast. Then one needs to define what fraction of the ions are in the fast population
    - <img width="599" alt="Screenshot 2023-08-08 at 11 20 15 AM" src="https://github.com/fsciortino/Aurora/assets/71457911/ab9f9934-abc2-42b1-b77c-2be70ca1fe81">
- Placeholders for if in the future this ever gets improved on

Minimum working code (simulating He-like Kr):
```
import aurora
import os

# Inputs
adf15_file = os.path.join(
    '/home/cjperks/tofu_sparc/atomic_data/ADAS_PEC_files',
    'Krypton',
    'fs#0.50A_8.50A#kr34.dat'
    )
Te_eV = Ti_eV = 3e3
ne_cm3 = 1e14 

dbroad = {
    'Suprathermal_Ions':{
        'model': 'Bi-Maxwellian',
        'Ti_eV': Ti_eV, # slow population ion temp
        'ion_A':  83.8,
        'Ti_fast_eV': 100e3, # fast population ion temp
        'f_fast': 1/2, # fraction of ions in fast population
        }
    }
out = aurora.get_local_spectrum(
    adf15_file,
    ne_cm3,
    Te_eV,
    ion_exc_rec_dens=[0,1,0],
    Ti_eV=Ti_eV,
    n0_cm3=0.0,
    dlam_A=0.0,
    plot_spec_tot=False,
    dbroad=dbroad,
    )

```