### PR TITLE
caching for adas files loading

### DIFF
--- a/aurora/atomic.py
+++ b/aurora/atomic.py
@@ -329,7 +329,6 @@ def read_filter_response(filepath, adas_format=True, plot=False):
 
     return E_eV, response
 
-
 @lru_cache(maxsize=1000)
 def load_adas_file_with_cache(fileloc):
     """Wrapper around the adas_file loading mechanism to enable implementation

--- a/aurora/atomic.py
+++ b/aurora/atomic.py
@@ -23,6 +23,7 @@ Refer also to the adas_files.py script.
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from functools import lru_cache
 import numpy as np
 import matplotlib.pyplot as plt
 from scipy.interpolate import RectBivariateSpline, interp1d, RegularGridInterpolator
@@ -329,6 +330,25 @@ def read_filter_response(filepath, adas_format=True, plot=False):
     return E_eV, response
 
 
+@lru_cache(maxsize=1000)
+def load_adas_file_with_cache(fileloc):
+    """Wrapper around the adas_file loading mechanism to enable implementation
+    of a granular caching system at file level. Each file would on average
+    account for less than 100kB, as such I have arbitrarily choosen to cap the
+    cache size to 1000, therefore preventing the cache to ever occupy more than
+    100MB in worst case scenario.
+
+    Parameters
+    ----------
+    fileloc : str containing the address of the adas file to load.
+
+    Returns
+    -------
+    The in-memory representation of the loaded adas file.
+    """
+    return adas_file(fileloc)
+
+
 def get_atom_data(imp, files=["acd", "scd"]):
     """Collect atomic data for a given impurity from all types of ADAS files available or
     for only those requested.
@@ -392,8 +412,7 @@ def get_atom_data(imp, files=["acd", "scd"]):
         fileloc = adas_files.get_adas_file_loc(all_files[filetype], filetype="adf11")
 
         # load specific file and add it to output dictionary
-        res = adas_file(fileloc)
-        atom_data[filetype] = adas_file(fileloc)
+        atom_data[filetype] = load_adas_file_with_cache(fileloc)
         # {'lne': res.logNe, 'lte': res.logT, 'ldata': res.data,
         #'meta_ind': res.meta_ind, 'meta': res.metastables}
 


### PR DESCRIPTION
Hi,
This should speed up the loading of the adas files especially in a scenario where we repeat the loading of the same files many times (ex: optimization or uncertainty quantification).