### PR TITLE
Fix SciPy.integrate naming

### DIFF
--- a/aurora/atomic.py
+++ b/aurora/atomic.py
@@ -32,7 +32,6 @@ import os, sys, copy
 import scipy.ndimage
 from scipy.linalg import svd
 from scipy import constants
-from scipy.integrate import simps
 from . import adas_files
 
 

--- a/aurora/core.py
+++ b/aurora/core.py
@@ -28,7 +28,7 @@ from scipy.interpolate import interp1d
 from scipy.constants import e as q_electron, m_p
 import pickle as pkl
 from copy import deepcopy
-from scipy.integrate import cumtrapz
+from scipy.integrate import cumulative_trapezoid
 from scipy.linalg import solve_banded
 import matplotlib.pyplot as plt
 from . import interp
@@ -1374,7 +1374,7 @@ class aurora_sim:
         n_state = len(meta_ind)
 
         # uvec
-        exp_diag = np.exp(cumtrapz(v_btw / D_btw, r_btw, initial=0, axis=-1))
+        exp_diag = np.exp(cumulative_trapezoid(v_btw / D_btw, r_btw, initial=0, axis=-1))
         exp_diag /= exp_diag[..., [-1]]
 
         exp_Dr = 1 / (exp_diag * D_btw * r_btw)  # diagonal of the matrix
@@ -1832,7 +1832,7 @@ class aurora_sim:
         reservoirs["net_plasma_flow"] = reservoirs["plasma_source"] + reservoirs["wall_source"] + reservoirs["divertor_source"] + reservoirs["plasma_removal_rate"]
 
         # integrated source over time
-        reservoirs["integ_source"] = cumtrapz(reservoirs["source"], self.time_out, initial=0) + reservoirs["total"][0] 
+        reservoirs["integ_source"] = cumulative_trapezoid(reservoirs["source"], self.time_out, initial=0) + reservoirs["total"][0] 
         
         # main plasma content
         if self.namelist["phys_volumes"]:    

--- a/aurora/kn1d.py
+++ b/aurora/kn1d.py
@@ -36,7 +36,7 @@ from scipy.interpolate import interp1d
 import numpy as np
 import os
 import scipy.io
-from scipy.integrate import cumtrapz
+from scipy.integrate import cumulative_trapezoid
 from scipy.interpolate import interp1d
 import matplotlib.pyplot as plt
 from scipy.constants import e, h, c as c_light, Rydberg
@@ -550,7 +550,7 @@ exit
     Sion_interp = interp1d(out["xh"], Sion, bounds_error=False, fill_value=0.0)(
         kn1d["x"]
     )
-    out["Gamma_i"] = cumtrapz(Sion_interp, kn1d["x"], initial=0.0)
+    out["Gamma_i"] = cumulative_trapezoid(Sion_interp, kn1d["x"], initial=0.0)
 
     # Effective diffusivity
     out["D_eff"] = np.abs(

--- a/aurora/nbi_neutrals.py
+++ b/aurora/nbi_neutrals.py
@@ -563,10 +563,10 @@ def bt_rate_maxwell_average(sigma_fun, Ti_keV, E_beam, m_bckg, m_beam, n_level):
                 sig * np.sqrt(u2) * np.exp(-(vz[i] ** 2.0 + vr[j] ** 2.0)) * vr[j]
             )
 
-        fz[:, :, i] = scipy.integrate.simps(fr, vr, axis=-1)
+        fz[:, :, i] = scipy.integrate.simpson(fr, vr, axis=-1)
 
     # effective maxwellian-averaged rate:
-    sig_eff = (2.0 / np.sqrt(np.pi)) * scipy.integrate.simps(fz, vz, axis=-1)
+    sig_eff = (2.0 / np.sqrt(np.pi)) * scipy.integrate.simpson(fz, vz, axis=-1)
     rate = sig_eff * v_therm
 
     return rate
@@ -631,6 +631,6 @@ def tt_rate_maxwell_average(sigma_fun, Ti_keV, m_i, m_n, n_level):
         )
 
     prefactor = np.sqrt(2.0 / (np.pi * T_per_amu)) ** (-0.5)
-    sigmav = prefactor * scipy.integrate.simps(sigma, Erel, axis=-1)
+    sigmav = prefactor * scipy.integrate.simpson(sigma, Erel, axis=-1)
 
     return sigmav

--- a/aurora/radiation.py
+++ b/aurora/radiation.py
@@ -23,7 +23,7 @@
 import os, sys, re
 import numpy as np
 from scipy.interpolate import RectBivariateSpline, interp1d
-from scipy.integrate import cumtrapz
+from scipy.integrate import cumulative_trapezoid
 import matplotlib.pyplot as plt
 
 plt.ion()
@@ -464,15 +464,15 @@ def radiation_model(
     out["rad_tot_dens"] = rad["tot"][0, :] * 1e6
 
     # cumulative integral over all volume
-    out["line_rad"] = cumtrapz(out["line_rad_dens"], vol, initial=0.0)
-    out["line_rad_tot"] = cumtrapz(out["line_rad_dens"].sum(0), vol, initial=0.0)
-    out["cont_rad"] = cumtrapz(out["cont_rad_dens"], vol, initial=0.0)
-    out["brems"] = cumtrapz(out["brems_dens"], vol, initial=0.0)
-    out["rad_tot"] = cumtrapz(out["rad_tot_dens"], vol, initial=0.0)
+    out["line_rad"] = cumulative_trapezoid(out["line_rad_dens"], vol, initial=0.0)
+    out["line_rad_tot"] = cumulative_trapezoid(out["line_rad_dens"].sum(0), vol, initial=0.0)
+    out["cont_rad"] = cumulative_trapezoid(out["cont_rad_dens"], vol, initial=0.0)
+    out["brems"] = cumulative_trapezoid(out["brems_dens"], vol, initial=0.0)
+    out["rad_tot"] = cumulative_trapezoid(out["rad_tot_dens"], vol, initial=0.0)
 
     if n0_cm3 is not None:
         out["thermal_cx_rad_dens"] = rad["thermal_cx_cont_rad"][0, :, :] * 1e6
-        out["thermal_cx_rad"] = cumtrapz(
+        out["thermal_cx_rad"] = cumulative_trapezoid(
             out["thermal_cx_rad_dens"].sum(0), vol, initial=0.0
         )
 


### PR DESCRIPTION
The scipy.integrate functions cumtrapz and simps were renamed as cumulative_trapezoid and simpson, respectively. The old names were depricated and later removed in SciPy 1.6.0, see
https://docs.scipy.org/doc/scipy/release/1.6.0-notes.html#scipy-integrate-improvements